### PR TITLE
refactor: centralize the retrograde symbol definition into a new constant

### DIFF
--- a/src/settings/constants/Point.js
+++ b/src/settings/constants/Point.js
@@ -21,3 +21,12 @@ export const POINT_PROPERTIES_FONT_SIZE = 16
 * @default 2
 */
 export const POINT_COLLISION_RADIUS = 12
+
+/**
+ * Retrograde symbol
+ * @constant
+ * @type {String}
+ * @property choices M for Px symbol or N for R symbol
+ * @default "M"
+ */
+export const POINT_RETROGRADE_SYMBOL = "M"

--- a/src/settings/constants/Point.js
+++ b/src/settings/constants/Point.js
@@ -29,4 +29,4 @@ export const POINT_COLLISION_RADIUS = 12
  * @property choices M for Px symbol or N for R symbol
  * @default "M"
  */
-export const POINT_RETROGRADE_SYMBOL = "M"
+export const POINT_RETROGRADE_SYMBOL_CODE = "M"

--- a/src/utils/SVGUtils.js
+++ b/src/utils/SVGUtils.js
@@ -1,3 +1,5 @@
+import { POINT_RETROGRADE_SYMBOL } from '../settings/constants/Point.js';
+
 /**
  * @class
  * @classdesc SVG utility class
@@ -90,7 +92,7 @@ class SVGUtils {
   static SYMBOL_MC_CODE = "d";
   static SYMBOL_IC_CODE = "e";
 
-  static SYMBOL_RETROGRADE_CODE = "M"
+  static SYMBOL_RETROGRADE_CODE = POINT_RETROGRADE_SYMBOL;
 
   static SYMBOL_CONJUNCTION_CODE = "!";
   static SYMBOL_OPPOSITION_CODE = '"';
@@ -679,5 +681,5 @@ class SVGUtils {
 
 export {
   SVGUtils as
-  default
+    default
 }

--- a/src/utils/SVGUtils.js
+++ b/src/utils/SVGUtils.js
@@ -1,4 +1,4 @@
-import { POINT_RETROGRADE_SYMBOL } from '../settings/constants/Point.js';
+import { POINT_RETROGRADE_SYMBOL_CODE } from '../settings/constants/Point.js';
 
 /**
  * @class
@@ -92,7 +92,7 @@ class SVGUtils {
   static SYMBOL_MC_CODE = "d";
   static SYMBOL_IC_CODE = "e";
 
-  static SYMBOL_RETROGRADE_CODE = POINT_RETROGRADE_SYMBOL;
+  static SYMBOL_RETROGRADE_CODE = POINT_RETROGRADE_SYMBOL_CODE;
 
   static SYMBOL_CONJUNCTION_CODE = "!";
   static SYMBOL_OPPOSITION_CODE = '"';


### PR DESCRIPTION
## Description
This change will allow the user to specify which retrograde symbol they want to use.

## Changes Made
Added POINT_RETROGRADE_SYMBOL constant in settings
Modified the initialization of the static property SVGUtils.SYMBOL_RETROGRADE_CODE to directly use this constant instead of the letter "M".